### PR TITLE
Export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "clean": "rimraf lib dist es",
-    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min && npm run build:es",
+    "build": "npm run build:commonjs && npm run build:types && npm run build:umd && npm run build:umd:min && npm run build:es",
     "prepublish": "npm run clean && npm run test && npm run build",
     "postpublish": "git add -A package.json src dist lib es && git commit -m \"publish v${npm_package_version}\"; bin/tag-with-changelog.sh v${npm_package_version} && git push && git push --tags",
     "posttest": "npm run lint",
@@ -21,7 +21,8 @@
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack",
-    "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack"
+    "build:umd:min": "cross-env BABEL_ENV=commonjs NODE_ENV=production webpack",
+    "build:types": "node scripts/export-types.js"
   },
   "repository": {
     "type": "git",
@@ -59,6 +60,7 @@
     "expect": "^1.16.0",
     "flow-bin": "^0.25.0",
     "mocha": "^2.2.5",
+    "recursive-copy": "^2.0.5",
     "rimraf": "^2.5.2",
     "webpack": "^1.12.14"
   },

--- a/scripts/export-types.js
+++ b/scripts/export-types.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var copy = require('recursive-copy')
+
+copy('src', 'lib', {
+  overwrite: true,
+  filter: '*.js',
+  rename: function(path) { return path + '.flow' }
+})
+.then(function(results) {
+  results.forEach(function(result) {
+    console.error(result.src + ' -> ' + result.dest)
+  })
+  process.exit(0)
+})
+.catch(function(err) {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Ok, here is a much simpler option for exporting type information. I could not find an existing command-line javascript tool to copy and rename, so I wrote a little script using the recursive-copy library.
