### PR TITLE
change all error values in store to be Error objects (fix #15)

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -70,13 +70,10 @@ function byIdReducer(state = byIdInitialState, action) {
                   .setIn([id.toString(), 'record'], fromJS(action.payload))
     case FETCH_ONE_ERROR:
       return state.setIn([id.toString(), 'fetchTime'], action.meta.fetchTime)
-                  .setIn([id.toString(), 'error'], fromJS(action.payload))
+                  .setIn([id.toString(), 'error'], action.payload)
                   .setIn([id.toString(), 'record'], null)
     case CREATE_SUCCESS:
       const cid = action.payload.id
-      if (state.get(cid.toString()) !== undefined) {
-        // console.error(`There was already a record at that id (${action.payload.id}) - erasing!`)
-      }
       return state.set(action.payload.id.toString(), fromJS({
         record: action.payload,
         fetchTime: action.meta.fetchTime,
@@ -121,7 +118,7 @@ function collectionReducer(state = collectionInitialState, action) {
                   .set('fetchTime', action.meta.fetchTime)
     case FETCH_ERROR:
       return state.set('params', fromJS(action.meta.params))
-                  .set('error', fromJS(action.payload))
+                  .set('error', action.payload)
     default:
       return state
   }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -18,7 +18,7 @@ export type Selection<T> = {
   data?: T,
   isLoading: boolean,
   needsFetch: boolean,
-  error?: Error | { message: string },
+  error?: Error,
   fetch?: CrudAction<T>,
 }
 
@@ -119,18 +119,18 @@ function getRecordSelection<T>(modelName: Model, id: ID, crud: State): Selection
   const model = crud.getIn([modelName, 'byId', id_str])
 
   if (model && model.get('fetchTime') === 0) {
-    return { isLoading: true, needsFetch: false, error: { message: 'Loading...' } }
+    return { isLoading: true, needsFetch: false, error: new Error('Loading...') }
   }
   if (id === undefined || model === undefined ||
       !recent(model.get('fetchTime'))) {
-    return { isLoading: true, needsFetch: true, error: { message: 'Loading...' } }
+    return { isLoading: true, needsFetch: true, error: new Error('Loading...') }
   }
 
   if (model.get('error') !== null) {
     return {
       isLoading: false,
       needsFetch: false,
-      error: model.get('error').toJS()
+      error: model.get('error')
     }
   }
   return {

--- a/test/selectors.spec.js
+++ b/test/selectors.spec.js
@@ -173,8 +173,8 @@ describe('selectRecord', () => {
     })
 
     describe('model has an error', () => {
-      const loadFailed = { status: 500, message: '500 Internal Server Error', time: now }
-      const errorModels = crud.setIn([modelName, 'byId', '1', 'error'], fromJS(loadFailed))
+      const loadFailed = new Error('500 Interval Server Error')
+      const errorModels = crud.setIn([modelName, 'byId', '1', 'error'], loadFailed)
       it('renders the error', () => {
         expect(selectRecord(modelName, 1, errorModels)).toEqual({
           isLoading: false,


### PR DESCRIPTION
It works out well because you can still use error.message. I think this is really just a patch release, but I think this will be 4.1.0 just because it's a significantish change.
