### PR TITLE
allow responses w/o data envelope. workaround for #6 until #19 is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ If you ever worry about your cache getting out of sync, it's easy to manually sy
 
 - allow dispatching multiple actions for API_CALL
 - consider allowing dispatching multiple actions for CREATE/UPDATE/DELETE
-- it would be great to support nested models - automatically stripping the models out of a parent object, moving them into their own store, and storing the parent with just an id reference. This might make component logic kind of intense if we aren't careful.
-- configurable keys: This module is still mostly agnostic about the format your data comes in from the server as, but in particular it expects records to live in response.data when running FETCH, and it expects all records to have an id attribute. It would be great to analyze this further and make those keys configurable.
+- configurable keys: It would be great to integrate normalizr, so people could specify a response schema and have their data automatically normalized into the store. This would also enable support for nested models for free.
+- it would be great to support nested models in selectors, perhaps using normalizr somehow.
 - tests for every public function
 - tests for every private function too
 

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -43,7 +43,7 @@ export type CrudAction<T> = {
 export type Success<T:{ id: ID }> = {
   type: typeof FETCH_SUCCESS | typeof FETCH_ONE_SUCCESS | typeof CREATE_SUCCESS | typeof UPDATE_SUCCESS | typeof DELETE_SUCCESS,
   meta: Meta,
-  payload: {
+  payload: T | {
     data: T,
   },
   error?: boolean,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -53,7 +53,8 @@ function byIdReducer(state = byIdInitialState, action) {
   switch (action.type) {
     case FETCH_SUCCESS:
       const data = state.toJS()
-      action.payload.data.forEach((record) => {
+      const payload = ('data' in action.payload) ? action.payload.data : action.payload
+      payload.forEach((record) => {
         data[record.id] = {
           record,
           fetchTime: action.meta.fetchTime,
@@ -111,10 +112,13 @@ function collectionReducer(state = collectionInitialState, action) {
                   .set('fetchTime', 0)
                   .set('error', null)
     case FETCH_SUCCESS:
-      const ids = action.payload.data.map((elt) => elt.id)
+      const originalPayload = action.payload || {}
+      const payload = ('data' in originalPayload) ? action.payload.data : action.payload
+      const otherInfo = ('data' in originalPayload) ? originalPayload.delete('data') : {}
+      const ids = payload.map((elt) => elt.id)
       return state.set('params', fromJS(action.meta.params))
                   .set('ids', fromJS(ids))
-                  .set('otherInfo', fromJS(action.payload || {}).delete('data'))
+                  .set('otherInfo', fromJS(otherInfo))
                   .set('error', null)
                   .set('fetchTime', action.meta.fetchTime)
     case FETCH_ERROR:

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -114,7 +114,8 @@ function collectionReducer(state = collectionInitialState, action) {
     case FETCH_SUCCESS:
       const originalPayload = action.payload || {}
       const payload = ('data' in originalPayload) ? action.payload.data : action.payload
-      const otherInfo = ('data' in originalPayload) ? originalPayload.delete('data') : {}
+      const otherInfo = ('data' in originalPayload) ? originalPayload : {}
+      if ('data' in originalPayload) delete otherInfo.data
       const ids = payload.map((elt) => elt.id)
       return state.set('params', fromJS(action.meta.params))
                   .set('ids', fromJS(ids))


### PR DESCRIPTION
`grep -r 'action.payload.data' src/` returns only these two lines now, so I believe this should cover people who have responses without a data envelope. I need someone to test this though before I feel happy merging it in. @mxmtsk would you be interested in trying this branch out with your project? I could merge this as 4.3.0 this week if it works for you.
