### PR TITLE
Small word change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module contains helper functions to make it easier to keep your models in s
 
 See [docs/API.md](https://github.com/uniqueway/redux-crud-store/blob/master/docs/API.md) for usage.
 
-There are four ways to integrate redux-crud-store into your app:
+There are four steps to integrating redux-crud-store into your app:
 
 1. Set up a redux-saga middleware
 2. Add the reducer to your store


### PR DESCRIPTION
The way the README is worded implies that I have a choice of 1-4 of how I wish to integrate `redux-crud-store` into my application. This PR clarifies that these are not options but rather steps to be performed.