### PR TITLE
Add README.md to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lib",
     "es",
     "src",
-    "dist"
+    "dist",
+    "README.md"
   ],
   "scripts": {
     "clean": "rimraf lib dist es",


### PR DESCRIPTION
This PR adds the README to the `files` list so that it will show up [in npm](https://www.npmjs.com/package/redux-crud-store).