### PR TITLE
fix opts set interval and when fetchTime is undefined (not null)

### DIFF
--- a/src/selectors.js
+++ b/src/selectors.js
@@ -33,9 +33,9 @@ export type SelectorOpts = {
  *  - fetchTime is 0 (but note, this won't return NEEDS_FETCH)
  */
 function recent(fetchTime, opts: SelectorOpts = {}) {
-  if (fetchTime === null) return false
+  if (!fetchTime) return false
 
-  const interval = opts.interval || 10 * 60 * 1000 // ten minutes
+  const interval = (opts && opts.interval) || 10 * 60 * 1000 // ten minutes
 
   return Date.now() - interval < fetchTime
 }
@@ -48,7 +48,7 @@ export function select<T>(action: CrudAction<T>, crud: State, opts: SelectorOpts
   let selection
   switch (action.type) {
     case FETCH:
-      selection = selectCollection(model, crud, params)
+      selection = selectCollection(model, crud, params, opts)
       break
     case FETCH_ONE:
       id = action.meta.id


### PR DESCRIPTION
This PR fix opts config interval for `recent()` and when the `fetchTime === undefined` issue.