### PR TITLE
fix #62 - bug preventing updates on records not already present

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -97,7 +97,7 @@ function byIdReducerImpl(state = byIdInitialState, action) {
       })
     case UPDATE:
       return Object.assign({}, state, {
-        [id]: {
+        [id]: state[id] === undefined ? undefined : {
           fetchTime: 0,
           error: state[id].error,
           record: state[id].record

--- a/test/byIdReducer.spec.js
+++ b/test/byIdReducer.spec.js
@@ -129,6 +129,15 @@ describe('byIdReducer', () => {
       const newState = byIdReducer(initialState, action)
       expect(newState[1].fetchTime).toEqual(0)
     })
+    it("can handle UPDATE even if record isn't present", () => {
+      const action = { type: UPDATE, meta: { id: 1 } }
+      deepFreeze(action)
+      const initialStateRecordNotPresent = {}
+      deepFreeze(initialStateRecordNotPresent)
+
+      const newState = byIdReducer(initialStateRecordNotPresent, action)
+      expect(newState[1]).toEqual(undefined)
+    })
     it('updates record on UPDATE_SUCCESS', () => {
       const action = {
         type: UPDATE_SUCCESS, meta: { id: 1 },


### PR DESCRIPTION
@NullVoxPopuli, are you able to try this locally and see if it fixes your issue?

You should be able to enter this in package.json to make it work:

    "redux-crud-store": "devvmh/redux-crud-store#allow-update-on-non-present-record",

If it's not working try

    rm -rf node_modules/redux-crud-store
    npm install