### PR TITLE
Handle merging of JSON-API responses during UPDATE_SUCCESS

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -108,7 +108,7 @@ function byIdReducerImpl(state = byIdInitialState, action) {
         [id]: {
           fetchTime: action.meta.fetchTime,
           error: null,
-          record: action.payload
+          record: ('data' in action.payload) ? action.payload.data : action.payload
         }
       })
     case DELETE_SUCCESS:
@@ -155,7 +155,7 @@ function collectionReducerImpl(state = collectionInitialState, action) {
           or
 
           [ ... ]
-        
+
           Here are the contents of your action:`)
         devMessage(JSON.stringify(action))
       }


### PR DESCRIPTION
I'm using a JSON-API backend, and the response after a `PUT` update request looks something like this:

```
{
  "data":{
    "id":"70",
    "type":"alert_emails",
    "links":{
      "self":"http://localhost:3000/api/v2/alert-emails/70"
    },
    "attributes":{
      "email":"user@example.com",
      "status":"pending"
    }
  }
}
```

The `{ "data": { ... } }` wrapper causes the updated record to have an extra top-level `data` key in the collection of all records, after `UPDATE_SUCCESS`.

<img width="669" alt="screen shot 2018-03-16 at 22 04 08" src="https://user-images.githubusercontent.com/96322/37522106-4d33813e-2966-11e8-9e80-d8dca3ad7e0a.png">

This solution is based on that already used in [FETCH_SUCCESS](
https://github.com/devvmh/redux-crud-store/blob/58e4039eebf8fd87807295eb664b34d496661a5e/src/reducers.js#L58).